### PR TITLE
Add django 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,12 @@ matrix:
   - python: '3.8'
     env: TOXENV=py38-dj30
   - python: '3.6'
+    env: TOXENV=py36-dj31
+  - python: '3.7'
+    env: TOXENV=py37-dj31
+  - python: '3.8'
+    env: TOXENV=py38-dj31
+  - python: '3.6'
     env: TOXENV=py36-djmaster
   - python: '3.7'
     env: TOXENV=py37-djmaster

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py{35,36,37}-dj21
     py{35,36,37}-dj22
     py{36,37,38}-dj30
+    py{36,37,38}-dj31
     py{36,37,38}-djmaster
 
 [testenv]
@@ -12,6 +13,7 @@ deps =
     dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<3.0
     dj30: Django>=3.0a1,<3.1
+    dj31: Django>=3.1a1,<3.2
     djmaster: https://github.com/django/django/archive/master.tar.gz
 commands = make test
 whitelist_externals = make


### PR DESCRIPTION
**Status:** Ready

If merged, this PR adds support for Django 3.1.

No code changes required but tox/travis environments updated to include it as part of test suite.