### PR TITLE
Bump setup.py requirements to 0.1.0 for ulid-py

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,4 +6,4 @@
 
 typing==3.7.4.1; python_version < '3.6'
 
-ulid-py>=0.0.9
+ulid-py==0.1.0

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     long_description=get_long_description(),
     packages=['django_ulid'],
     python_requires='>=3.5',
-    install_requires=['Django>=2.1', 'ulid-py>=0.0.9'],
+    install_requires=['Django>=2.1', 'ulid-py>=0.1.0'],
     classifiers=(
         'Development Status :: 4 - Beta',
         "Framework :: Django",


### PR DESCRIPTION
**Status:** Ready

If merged, bumps the setup.py requirement for ulid-py to 0.1.0+.

Related: https://github.com/ahawker/ulid/issues/452