### PR TITLE
Make ULIDField compatible with Django 5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Adding a ULID field to your Django models is straightforward. It can be a normal
 
 ```python
 from django.db import models
-from django_ulid.models import default, ULIDField
+from django_ulid.models import default_ulid, ULIDField
 
 class Person(models.Model):
-    id = ULIDField(default=default, primary_key=True, editable=False)
+    id = ULIDField(primary_key=True, default=default_ulid, editable=False)
 ```
 
 Passing in `default` to the `ULIDField` will automatically create a default value using the [ulid.new](https://ulid.readthedocs.io/en/latest/api.html#ulid.api.new) function.

--- a/django_ulid/models.py
+++ b/django_ulid/models.py
@@ -1,62 +1,68 @@
-"""
-    django_ulid/models
-    ~~~~~~~~~~~~~~~~~~
-
-    Contains functionality for Django model support.
-"""
+import uuid
 import ulid
+
 from django.core import exceptions
 from django.db import models
+from django.db.migrations.serializer import BaseSerializer
+from django.db.migrations.writer import MigrationWriter
 from django.utils.translation import gettext as _
 
-from . import forms
 
-# Helper attr so callers don't need to import the ulid package.
-default = ulid.new
+class ULIDSerializer(BaseSerializer):
+    def serialize(self):
+        return "ulid.ULID(%s)" % bytes(self.value), {"import ulid"}
 
 
-class ULIDField(models.Field):
+MigrationWriter.register_serializer(ulid.ULID, ULIDSerializer)
+
+
+def default_ulid():
+    return ulid.ULID()
+
+
+class ULIDField(models.UUIDField):
     """
     Django model field type for handling ULID's.
 
     This field type is natively stored in the DB as a UUID (when supported) and a string/varchar otherwise.
     """
-    description = 'Universally Unique Lexicographically Sortable Identifier'
+
+    default_error_messages = {
+        "invalid": _("“%(value)s” is not a valid ULID."),
+    }
+    description = "Universally Unique Lexicographically Sortable Identifier"
     empty_strings_allowed = False
 
     def __init__(self, verbose_name=None, **kwargs):
-        kwargs.setdefault('max_length', 26)
         super().__init__(verbose_name, **kwargs)
-
-    def deconstruct(self):
-        name, path, args, kwargs = super().deconstruct()
-        del kwargs['max_length']
-        return name, path, args, kwargs
-
-    def get_internal_type(self):
-        return 'UUIDField'
+        self.max_length = 26
+        self.serialize = True
 
     def get_db_prep_value(self, value, connection, prepared=False):
         if value is None:
             return None
         if not isinstance(value, ulid.ULID):
             value = self.to_python(value)
-        return value.uuid if connection.features.has_native_uuid_field else str(value)
+        return value.to_uuid4() if connection.features.has_native_uuid_field else value.hex
+
+    def get_internal_type(self):
+        return "UUIDField"
 
     def from_db_value(self, value, expression, connection):
         return self.to_python(value)
 
     def to_python(self, value):
-        if value is None:
-            return None
-        try:
-            return ulid.parse(value)
-        except (AttributeError, ValueError):
-            raise exceptions.ValidationError(
-                _("'%(value)s' is not a valid ULID."),
-                code='invalid',
-                params={'value': value}
-            )
+        if value is not None and not isinstance(value, ulid.ULID):
+            try:
+                if isinstance(value, uuid.UUID):
+                    value = ulid.ULID.from_uuid(value)
+                if isinstance(value, str):
+                    value = ulid.ULID.from_str(value)
+            except (AttributeError, ValueError):
+                raise exceptions.ValidationError(
+                    _("'%(value)s' is not a valid ULID."), code="invalid", params={"value": value}
+                )
+        return value
 
     def formfield(self, **kwargs):
         return super().formfield(**{


### PR DESCRIPTION
I couldn't build the package with the new changes, likely because of an outdated `setup.py` configuration, but the field implementation works in `Django 5.0.2` as I tested.

PS: The current package version is not compatible with the latest `python-ulid` package, so that dependency needs to be updated as well. 